### PR TITLE
test: Update tests to use unknown error type

### DIFF
--- a/src/utils/music.spec.ts
+++ b/src/utils/music.spec.ts
@@ -156,9 +156,12 @@ describe("Music utils", () => {
     try {
       await getSongInfo(dummyArgs);
     } catch (e) {
-      expect(e instanceof MusicResultError).toBe(true);
-      expect(e.message).toBe(messageContent.error.music.ytsrNoResults);
-      expect(ytsr).toHaveBeenCalledWith(dummyArgs.join(" "), { limit: 50 });
+      const isMusicResultError = e instanceof MusicResultError;
+      expect(isMusicResultError).toBe(true);
+      if (isMusicResultError) {
+        expect(e.message).toBe(messageContent.error.music.ytsrNoResults);
+        expect(ytsr).toHaveBeenCalledWith(dummyArgs.join(" "), { limit: 50 });
+      }
     }
   });
 });

--- a/src/utils/parser.spec.ts
+++ b/src/utils/parser.spec.ts
@@ -1,3 +1,5 @@
+import { CommandError } from "../errors/command";
+import { ParsingError } from "../errors/parser";
 import messageContent from "../message-content";
 import {
   getCommandByName,
@@ -36,7 +38,11 @@ describe("Parser", () => {
     try {
       parseCommand(msg);
     } catch (e) {
-      expect(e.message).toBe("Command name undefined");
+      const isParsingError = e instanceof ParsingError;
+      expect(isParsingError).toBe(true);
+      if (isParsingError) {
+        expect(e.message).toBe("Command name undefined");
+      }
     }
   });
 
@@ -66,7 +72,11 @@ describe("Parser", () => {
     try {
       getCommandByName(commandName);
     } catch (e) {
-      expect(e.message).toBe(messageContent.error.command.notFound);
+      const isCommandError = e instanceof CommandError;
+      expect(isCommandError).toBe(true);
+      if (isCommandError) {
+        expect(e.message).toBe(messageContent.error.command.notFound);
+      }
     }
   });
 });


### PR DESCRIPTION
This is necessary, as TypeScript types errors as `unknown` since [version 4.4][0]. This should get #281 merged.

[0]: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-4.html#defaulting-to-the-unknown-type-in-catch-variables---useunknownincatchvariables